### PR TITLE
Add python to generators image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN cargo install uniffi-bindgen-cs --tag v0.4.0+v0.23.0 --git https://github.co
 RUN cargo install uniffi-bindgen-go --tag v0.1.5+v0.23.0 --git https://github.com/NordSecurity/uniffi-bindgen-go
 
 FROM debian:bullseye
+
 COPY --from=builder /usr/local/cargo/bin/uniffi-bindgen /bin
 COPY --from=builder /usr/local/cargo/bin/uniffi-bindgen-cs /bin
 COPY --from=builder /usr/local/cargo/bin/uniffi-bindgen-go /bin
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3 && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ shows which versions of each generator are inside the docker image.
 
 | Docker image           | uniffi-rs version | uniffi-bindgen-cs version | uniffi-bindgen-go version |
 |------------------------|-------------------|---------------------------|---------------------------|
+| v0.23.0-6              | v0.23.0-3 (FORK)  | v0.4.0+v0.23.0            | v0.1.5+v0.23.0            |
 | v0.23.0-5              | v0.23.0-3 (FORK)  | v0.4.0+v0.23.0            | v0.1.5+v0.23.0            |
 | v0.23.0-4              | v0.23.0 (FORK)    | v0.2.3+v0.23.0            | v0.1.3+v0.23.0            |
 | v0.23.0-3 (DO NOT USE) | v0.23.0 (FORK)    | v0.2.2+v0.23.0            | v0.1.0+v0.23.0            |
 | v0.23.0-2 (DO NOT USE) | v0.23.0           | v0.2.1+v0.23.0            | v0.1.0+v0.23.0            |
 | v0.23.0-1              | v0.23.0           | v0.2.1+v0.23.0            | not present               |
+
+### v0.23.0-6
+
+`uniffi-generators`
+- Include `python3` installation in the *docker* image
 
 ### v0.23.0-5
 


### PR DESCRIPTION
Generated bindings sometimes require some additional modification, which is easier to perform in python than in bash. This adds the python installation to the generator image.