### PR TITLE
[LLT-6597] Bump uniffi-bindgen-cs version from v0.9.1+v0.28.3 to v0.9.2+v0.28.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /project
 RUN cargo search --limit 1
 
 RUN cd /project && cargo install --path uniffi-bindgen
-RUN cargo install uniffi-bindgen-cs --tag v0.9.1+v0.28.3 --git https://github.com/NordSecurity/uniffi-bindgen-cs
+RUN cargo install uniffi-bindgen-cs --tag v0.9.2+v0.28.3 --git https://github.com/NordSecurity/uniffi-bindgen-cs
 RUN cargo install uniffi-bindgen-go --tag v0.4.0+v0.28.3 --git https://github.com/NordSecurity/uniffi-bindgen-go
 RUN cargo install uniffi-bindgen-cpp --tag v0.7.2+v0.28.3 --git https://github.com/NordSecurity/uniffi-bindgen-cpp
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ images with all these generators in their compatible versions.
 
 Start docker container with image from this repository e.g.:
 ```
-ghcr.io/NordSecurity/uniffi-generators:v0.28.3-3
+ghcr.io/NordSecurity/uniffi-generators:v0.28.3-4
 ```
 Inside docker you can run:
 ```
@@ -38,6 +38,7 @@ shows which versions of each generator are inside the docker image.
 
 | Docker image           | uniffi-rs version     | uniffi-bindgen-cs version | uniffi-bindgen-go version | uniffi-bindgen-cpp version |
 |------------------------|-----------------------|---------------------------|---------------------------|----------------------------|
+| v0.28.3-4              | v0.28.3               | **v0.9.2+v0.28.3**        | v0.4.0+v0.28.3            | v0.7.2+v0.28.3             |
 | v0.28.3-3              | v0.28.3               | v0.9.1+v0.28.3            | **v0.4.0+v0.28.3**        | **v0.7.2+v0.28.3**         |
 | v0.28.3-1              | **v0.28.3**           | **v0.9.1+v0.28.3**        | **v0.3.0+v0.28.3**        | **v0.7.0+v0.28.3**         |
 | v0.25.0-15             | v0.3.3+v0.25.0        | v0.8.3+v0.25.0            | v0.2.2+v0.25.0            | **v0.6.4+v0.25.0**         |

--- a/compatibility-test/setup_test_source.sh
+++ b/compatibility-test/setup_test_source.sh
@@ -33,7 +33,7 @@ download_file "$GITHUB_URL/fixtures/coverall/tests/bindings/test_coverall.kts"  
 download_file "$GITHUB_URL/fixtures/coverall/tests/bindings/test_coverall.py"    "$TMP_DIR/python"
 download_file "$GITHUB_URL/fixtures/coverall/tests/bindings/test_coverall.swift" "$TMP_DIR/swift"
 
-GITHUB_VERSION="v0.9.1+v0.28.3"
+GITHUB_VERSION="v0.9.2+v0.28.3"
 GITHUB_URL="https://raw.githubusercontent.com/NordSecurity/uniffi-bindgen-cs/$GITHUB_VERSION"
 download_file "$GITHUB_URL/dotnet-tests/UniffiCS.BindingTests/TestCoverall.cs"                 "$TMP_DIR/cs/UniffiCS.binding_tests"
 download_file "$GITHUB_URL/dotnet-tests/UniffiCS.BindingTests/UniffiCS.BindingTests.csproj"    "$TMP_DIR/cs/UniffiCS.binding_tests"


### PR DESCRIPTION
An important [fix](https://github.com/NordSecurity/uniffi-bindgen-cs/pull/144) has been merged into C# uniffi binding generators, therefore bumping the version in docker images.